### PR TITLE
Updated SQLite.swift submodule and made it compile

### DIFF
--- a/SQLiteCipher.xcodeproj/project.pbxproj
+++ b/SQLiteCipher.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		80EC45611C4316CD00BADFB1 /* Cipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EC45601C4316CD00BADFB1 /* Cipher.swift */; };
 		80EC45631C43188800BADFB1 /* SQLite.h in Headers */ = {isa = PBXBuildFile; fileRef = 80EC45621C43188800BADFB1 /* SQLite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80EC45691C43197700BADFB1 /* libsqlcipher.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 80EC44D51C4315A900BADFB1 /* libsqlcipher.a */; };
+		9C1B9D511CA5C93500EF0A1E /* Foundation+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1B9D501CA5C93500EF0A1E /* Foundation+extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -116,6 +117,7 @@
 		80EC45481C43169C00BADFB1 /* Setter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Setter.swift; sourceTree = "<group>"; };
 		80EC45601C4316CD00BADFB1 /* Cipher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cipher.swift; sourceTree = "<group>"; };
 		80EC45621C43188800BADFB1 /* SQLite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQLite.h; sourceTree = "<group>"; };
+		9C1B9D501CA5C93500EF0A1E /* Foundation+extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Foundation+extension.swift"; path = "SQLiteCipher/Foundation+extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +143,7 @@
 		80EC448F1C4314EE00BADFB1 = {
 			isa = PBXGroup;
 			children = (
+				9C1B9D501CA5C93500EF0A1E /* Foundation+extension.swift */,
 				80EC449B1C4314EE00BADFB1 /* SQLiteCipher */,
 				80EC44A71C4314EE00BADFB1 /* SQLiteCipherTests */,
 				80EC449A1C4314EE00BADFB1 /* Products */,
@@ -412,6 +415,7 @@
 				80EC454F1C43169C00BADFB1 /* Blob.swift in Sources */,
 				80EC45611C4316CD00BADFB1 /* Cipher.swift in Sources */,
 				80EC45561C43169C00BADFB1 /* R*Tree.swift in Sources */,
+				9C1B9D511CA5C93500EF0A1E /* Foundation+extension.swift in Sources */,
 				80EC45521C43169C00BADFB1 /* SQLite-Bridging.m in Sources */,
 				80EC45541C43169C00BADFB1 /* Value.swift in Sources */,
 				80EC455B1C43169C00BADFB1 /* Expression.swift in Sources */,

--- a/SQLiteCipher.xcodeproj/project.pbxproj
+++ b/SQLiteCipher.xcodeproj/project.pbxproj
@@ -85,6 +85,27 @@
 			remoteGlobalIDString = D2AAC045055464E500DB518D;
 			remoteInfo = sqlcipher;
 		};
+		9C1B9D821CA5CDED00EF0A1E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 80EC44B31C43159800BADFB1 /* SQLite.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 03A65E5A1C6BB0F50062603F;
+			remoteInfo = "SQLite tvOS";
+		};
+		9C1B9D841CA5CDED00EF0A1E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 80EC44B31C43159800BADFB1 /* SQLite.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 03A65E631C6BB0F60062603F;
+			remoteInfo = "SQLiteTests tvOS";
+		};
+		9C1B9D861CA5CDED00EF0A1E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 80EC44B31C43159800BADFB1 /* SQLite.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A121AC451CA35C79005A31D1;
+			remoteInfo = "SQLite watchOS";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -117,7 +138,7 @@
 		80EC45481C43169C00BADFB1 /* Setter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Setter.swift; sourceTree = "<group>"; };
 		80EC45601C4316CD00BADFB1 /* Cipher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cipher.swift; sourceTree = "<group>"; };
 		80EC45621C43188800BADFB1 /* SQLite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQLite.h; sourceTree = "<group>"; };
-		9C1B9D501CA5C93500EF0A1E /* Foundation+extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Foundation+extension.swift"; path = "SQLiteCipher/Foundation+extension.swift"; sourceTree = "<group>"; };
+		9C1B9D501CA5C93500EF0A1E /* Foundation+extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Foundation+extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,7 +164,6 @@
 		80EC448F1C4314EE00BADFB1 = {
 			isa = PBXGroup;
 			children = (
-				9C1B9D501CA5C93500EF0A1E /* Foundation+extension.swift */,
 				80EC449B1C4314EE00BADFB1 /* SQLiteCipher */,
 				80EC44A71C4314EE00BADFB1 /* SQLiteCipherTests */,
 				80EC449A1C4314EE00BADFB1 /* Products */,
@@ -167,6 +187,7 @@
 				80EC449C1C4314EE00BADFB1 /* SQLiteCipher.h */,
 				80EC449E1C4314EE00BADFB1 /* Info.plist */,
 				80EC45601C4316CD00BADFB1 /* Cipher.swift */,
+				9C1B9D501CA5C93500EF0A1E /* Foundation+extension.swift */,
 				80EC454A1C43169C00BADFB1 /* SQLite */,
 			);
 			path = SQLiteCipher;
@@ -188,6 +209,9 @@
 				80EC452F1C43169400BADFB1 /* SQLiteTests iOS.xctest */,
 				80EC44C41C43159800BADFB1 /* SQLite.framework */,
 				80EC45311C43169400BADFB1 /* SQLiteTests Mac.xctest */,
+				9C1B9D831CA5CDED00EF0A1E /* SQLite.framework */,
+				9C1B9D851CA5CDED00EF0A1E /* SQLiteTests tvOS.xctest */,
+				9C1B9D871CA5CDED00EF0A1E /* SQLite.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -385,6 +409,27 @@
 			fileType = wrapper.cfbundle;
 			path = "SQLiteTests Mac.xctest";
 			remoteRef = 80EC45301C43169400BADFB1 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		9C1B9D831CA5CDED00EF0A1E /* SQLite.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SQLite.framework;
+			remoteRef = 9C1B9D821CA5CDED00EF0A1E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		9C1B9D851CA5CDED00EF0A1E /* SQLiteTests tvOS.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "SQLiteTests tvOS.xctest";
+			remoteRef = 9C1B9D841CA5CDED00EF0A1E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		9C1B9D871CA5CDED00EF0A1E /* SQLite.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SQLite.framework;
+			remoteRef = 9C1B9D861CA5CDED00EF0A1E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/SQLiteCipher.xcodeproj/project.pbxproj
+++ b/SQLiteCipher.xcodeproj/project.pbxproj
@@ -563,6 +563,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLiteCipher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "";
 			};
 			name = Debug;
 		};
@@ -581,6 +582,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stephencelis.SQLiteCipher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "";
 			};
 			name = Release;
 		};

--- a/SQLiteCipher.xcodeproj/project.pbxproj
+++ b/SQLiteCipher.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		80EC45631C43188800BADFB1 /* SQLite.h in Headers */ = {isa = PBXBuildFile; fileRef = 80EC45621C43188800BADFB1 /* SQLite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80EC45691C43197700BADFB1 /* libsqlcipher.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 80EC44D51C4315A900BADFB1 /* libsqlcipher.a */; };
 		9C1B9D511CA5C93500EF0A1E /* Foundation+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1B9D501CA5C93500EF0A1E /* Foundation+extension.swift */; };
+		9CEC27C01CA5D3BB002AA033 /* SQLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80EC44C01C43159800BADFB1 /* SQLite.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -146,6 +147,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9CEC27C01CA5D3BB002AA033 /* SQLite.framework in Frameworks */,
 				80EC45691C43197700BADFB1 /* libsqlcipher.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SQLiteCipher.xcodeproj/xcshareddata/xcschemes/SQLiteCipher.xcscheme
+++ b/SQLiteCipher.xcodeproj/xcshareddata/xcschemes/SQLiteCipher.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "80EC44981C4314EE00BADFB1"
+               BuildableName = "SQLiteCipher.framework"
+               BlueprintName = "SQLiteCipher"
+               ReferencedContainer = "container:SQLiteCipher.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "80EC44981C4314EE00BADFB1"
+            BuildableName = "SQLiteCipher.framework"
+            BlueprintName = "SQLiteCipher"
+            ReferencedContainer = "container:SQLiteCipher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "80EC44981C4314EE00BADFB1"
+            BuildableName = "SQLiteCipher.framework"
+            BlueprintName = "SQLiteCipher"
+            ReferencedContainer = "container:SQLiteCipher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SQLiteCipher.xcodeproj/xcshareddata/xcschemes/SQLiteCipherTests.xcscheme
+++ b/SQLiteCipher.xcodeproj/xcshareddata/xcschemes/SQLiteCipherTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "80EC44A21C4314EE00BADFB1"
+               BuildableName = "SQLiteCipherTests.xctest"
+               BlueprintName = "SQLiteCipherTests"
+               ReferencedContainer = "container:SQLiteCipher.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SQLiteCipher/Cipher.swift
+++ b/SQLiteCipher/Cipher.swift
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 //
 
-import SQLite3
+//import SQLite3
 
 extension Connection {
     

--- a/SQLiteCipher/Foundation+extension.swift
+++ b/SQLiteCipher/Foundation+extension.swift
@@ -1,0 +1,15 @@
+//
+//  Foundation+extension.swift
+//  SQLiteCipher
+//
+//  Created by Geoffrey Blotter on 3/25/16.
+//  Copyright © 2016 Stephen Celis. All rights reserved.
+//
+
+import Foundation
+
+extension NSData {
+	
+	public typealias Datatype = Blob.Datatype
+	
+}


### PR DESCRIPTION
In order for this to work, there needs to be an update to SQLite.swift: Foundation.swift -> Needs to have public typealias Datatype = Blob.Datatype added, like so:

```
extension NSData : Value {

   public typealias Datatype = Blob.Datatype

    public class var declaredDatatype: String {
        return Blob.declaredDatatype
    }

    public class func fromDatatypeValue(dataValue: Blob) -> NSData {
        return NSData(bytes: dataValue.bytes, length: dataValue.bytes.count)
    }

    public var datatypeValue: Blob {
        return Blob(bytes: bytes, length: length)
    }

}

```

However, in the mean time I added a Foundation+extension.swift and added that line there, so I didn't have to change/rely on a change in SQLite.swift
